### PR TITLE
Update VectPairStringChain definition and tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ThreeBodyDecays"
 uuid = "e6563dab-9ca1-5843-bde3-2ccf38d63843"
 authors = ["Misha Mikhasenko <mikhail.mikhasenko@gmail.com>"]
-version = "0.10.2"
+version = "0.10.3"
 
 [deps]
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"

--- a/src/model.jl
+++ b/src/model.jl
@@ -4,7 +4,7 @@
 	names::SVector{N, String}
 end
 
-const VectPairStringChain = Vector{Pair{String, Tuple{F, DC}}} where {F <: Number, DC <: AbstractDecayChain}
+const VectPairStringChain = AbstractVector{<:Pair{<:AbstractString, <:Tuple{<:Number, <:AbstractDecayChain}}}
 """
 	ThreeBodyDecay(; chains, couplings, names)
 
@@ -37,7 +37,7 @@ function ThreeBodyDecay(descriptor::VectPairStringChain)
 	# 
 	sv_chains = (SVector{N})(chains)
 	sv_couplings = SVector{N}(couplings)
-	sv_names = SVector{N}(names)
+	sv_names = SVector{N, String}(names)
 	#
 	ThreeBodyDecay(sv_chains, sv_couplings, sv_names)
 end

--- a/test/test_model.jl
+++ b/test/test_model.jl
@@ -1,5 +1,7 @@
 using Test
 using ThreeBodyDecays
+using StaticArrays
+
 
 # test model constraction
 model = let
@@ -23,7 +25,16 @@ model = let
 		"K(892)" .=> [(4.0, ch1), (2.0, ch2), (3.0, ch3)])
 end
 
-
+@testset "Construction with SVectors" begin
+	_model = ThreeBodyDecay(
+		SVector("K(892)", "K(892)", "K(892)") .=>
+			SVector(zip(model.couplings, model.chains)...))
+	@test _model == model
+	_model = ThreeBodyDecay(
+		SubString("K(892))", 1, 6) .=>
+			SVector(zip(model.couplings, model.chains)...))
+	@test _model == model
+end
 
 @testset "Properties of the model" begin
 	@test length(model) == 3


### PR DESCRIPTION
This pull request updates the definition of ´VectPairStringChain´ to use ´AbstractVector´ instead of ´Vector´.


It also includes updates to the tests for the ´ThreeBodyDecays´ module (´AbstractString´, and ´StaticVectors´)