### PR TITLE
implemented + tests

### DIFF
--- a/src/ThreeBodyDecays.jl
+++ b/src/ThreeBodyDecays.jl
@@ -66,8 +66,9 @@ include("tbs_struct.jl")
 
 export letterL
 export ⊗
-export possible_ls, possible_ls_ij, possible_ls_Rk, possible_lsLS
+export possible_ls, possible_ls_ij, possible_ls_Rk, possible_lsLS, possible_l_s_L_S
 export possible_coupling_schemes
+export complete_l_s_L_S
 include("coupling_scheme.jl")
 
 export change_basis_3from1, change_basis_1from2, change_basis_2from3

--- a/src/coupling_scheme.jl
+++ b/src/coupling_scheme.jl
@@ -1,7 +1,7 @@
 function possible_ls(jp1::SpinParity, jp2::SpinParity; jp::SpinParity)
-    two_ls = Vector{Tuple{Int,Int}}(undef, 0)
-    for two_s = abs(jp1.two_j - jp2.two_j):2:abs(jp1.two_j + jp2.two_j)
-        for two_l = abs(jp.two_j - two_s):2:abs(jp.two_j + two_s)
+    two_ls = Vector{Tuple{Int, Int}}(undef, 0)
+    for two_s ∈ abs(jp1.two_j - jp2.two_j):2:abs(jp1.two_j + jp2.two_j)
+        for two_l ∈ abs(jp.two_j - two_s):2:abs(jp.two_j + two_s)
             if jp1.p ⊗ jp2.p ⊗ jp.p == (isodd(div(two_l, 2)) ? '-' : '+')
                 push!(two_ls, (two_l, two_s))
             end
@@ -11,7 +11,7 @@ function possible_ls(jp1::SpinParity, jp2::SpinParity; jp::SpinParity)
 end
 
 
-const TwoBodyTopologySpinParity = Pair{SpinParity,Tuple{SpinParity,SpinParity}}
+const TwoBodyTopologySpinParity = Pair{SpinParity, Tuple{SpinParity, SpinParity}}
 possible_ls((jp, (jp1, jp2))::TwoBodyTopologySpinParity) = possible_ls(jp1, jp2; jp)
 possible_ls(jp1::AbstractString, jp2::AbstractString; jp::AbstractString) =
     possible_ls(str2jp(jp1), str2jp(jp2); jp = str2jp(jp))
@@ -28,6 +28,15 @@ function possible_lsLS(jp::SpinParity, two_js::SpinTuple, Ps::ParityTuple; k::In
     return [(; two_ls, two_LS) for (two_ls, two_LS) in Iterators.product(lsv, LSv)]
 end
 
+function possible_l_s_L_S(jp::SpinParity, two_js::SpinTuple, Ps::ParityTuple; k)
+    _lsLS = possible_lsLS(jp, two_js, Ps; k) |> vec
+    map(_lsLS) do (two_ls, two_LS)
+        l, s = two_ls .|> d2
+        L, S = two_LS .|> d2
+        (; l, s, L, S)
+    end
+end
+
 function jls_coupling(two_j1, two_λ1, two_j2, two_λ2, two_j, two_l, two_s)
     T1 = one(two_λ1) # type consistency
     return sqrt((two_l * T1 + 1) / (two_j * T1 + 1)) *
@@ -40,4 +49,62 @@ function jls_coupling(two_j1, two_λ1, two_j2, two_λ2, two_j, two_l, two_s)
                two_j,
                two_λ1 - two_λ2,
            )
+end
+
+
+function check_and_attach(data, df, df_all)
+    if size(df, 1) == 0
+        error("""
+        Decay description
+        $(data)
+        is inconsistent. Pick one of all possible,
+        $(df_all)
+        """)
+    end
+    if size(df, 1) > 1
+        for q in [:L, :l, :S, :s]
+            possible_q = unique(getproperty.(df, q))
+            !(q in keys(data)) && error("""
+            Decay description
+            $(data)
+            is not complete. Add $q = $(possible_q[1]), or other from list $(Tuple(possible_q))
+            """)
+        end
+    end
+    @unpack l, s, L, S = df[1]
+    return (; data..., l, s, L, S)
+end
+
+filter_qn!(possible_qn, constraints::NamedTuple) =
+    for var_name in [:L, :S, :l, :s]
+        if var_name in keys(constraints)
+            value = getproperty(constraints, var_name)
+            value_str = value |> x2 |> d2
+            filter!(x -> getproperty(x, var_name) == value_str, possible_qn)
+        end
+    end
+#
+function complete_l_s_L_S(jp::SpinParity,
+    two_js::SpinTuple,
+    Ps::ParityTuple,
+    constraints; k)
+    #
+    qn = possible_l_s_L_S(jp, two_js, Ps; k)
+    all_qn = copy(qn)
+    filter_qn!(qn, constraints)
+    complete_data = check_and_attach(constraints, qn, all_qn)
+    return complete_data
+end
+
+function complete_l_s_L_S(
+    jp::SpinParity,
+    two_js::SpinTuple,
+    several_Ps::AbstractArray{ParityTuple},
+    constraints; k)
+    #
+    qn = vcat([possible_l_s_L_S(jp, two_js, Ps; k) for Ps in several_Ps]...)
+    all_qn = copy(qn)
+    filter_qn!(qn, constraints)
+    complete_data = check_and_attach(constraints, qn, all_qn)
+    return complete_data
 end

--- a/src/coupling_scheme.jl
+++ b/src/coupling_scheme.jl
@@ -1,5 +1,5 @@
 function possible_ls(jp1::SpinParity, jp2::SpinParity; jp::SpinParity)
-    two_ls = Vector{Tuple{Int, Int}}(undef, 0)
+    two_ls = Vector{Tuple{Int,Int}}(undef, 0)
     for two_s ∈ abs(jp1.two_j - jp2.two_j):2:abs(jp1.two_j + jp2.two_j)
         for two_l ∈ abs(jp.two_j - two_s):2:abs(jp.two_j + two_s)
             if jp1.p ⊗ jp2.p ⊗ jp.p == (isodd(div(two_l, 2)) ? '-' : '+')
@@ -11,7 +11,7 @@ function possible_ls(jp1::SpinParity, jp2::SpinParity; jp::SpinParity)
 end
 
 
-const TwoBodyTopologySpinParity = Pair{SpinParity, Tuple{SpinParity, SpinParity}}
+const TwoBodyTopologySpinParity = Pair{SpinParity,Tuple{SpinParity,SpinParity}}
 possible_ls((jp, (jp1, jp2))::TwoBodyTopologySpinParity) = possible_ls(jp1, jp2; jp)
 possible_ls(jp1::AbstractString, jp2::AbstractString; jp::AbstractString) =
     possible_ls(str2jp(jp1), str2jp(jp2); jp = str2jp(jp))
@@ -84,10 +84,13 @@ filter_qn!(possible_qn, constraints::NamedTuple) =
         end
     end
 #
-function complete_l_s_L_S(jp::SpinParity,
+function complete_l_s_L_S(
+    jp::SpinParity,
     two_js::SpinTuple,
     Ps::ParityTuple,
-    constraints; k)
+    constraints;
+    k,
+)
     #
     qn = possible_l_s_L_S(jp, two_js, Ps; k)
     all_qn = copy(qn)
@@ -100,7 +103,9 @@ function complete_l_s_L_S(
     jp::SpinParity,
     two_js::SpinTuple,
     several_Ps::AbstractArray{ParityTuple},
-    constraints; k)
+    constraints;
+    k,
+)
     #
     qn = vcat([possible_l_s_L_S(jp, two_js, Ps; k) for Ps in several_Ps]...)
     all_qn = copy(qn)

--- a/test/test_couplings.jl
+++ b/test/test_couplings.jl
@@ -59,3 +59,28 @@ end
     @test letterL("2") == 'D'
     @test letterL(4 |> d2) == 'D'
 end
+
+
+(two_js, pc), (_, pv) = map(["1/2+", "1/2-"]) do jp0
+    ThreeBodySpinParities("1/2+", "0-", "0-"; jp0)
+end;
+
+@testset "Completing l, s, L, S" begin
+    qn = (jp = jp"1/2-", k = 2)
+    updated_qn = complete_l_s_L_S(qn.jp, two_js, pc, qn; qn.k)
+    @test updated_qn.l == "0"
+    @test updated_qn.s == "1/2"
+    @test updated_qn.L == "0"
+    @test updated_qn.S == "1/2"
+    #
+    qn = (jp = jp"2+", k = 1)
+    @test_throws ErrorException complete_l_s_L_S(qn.jp, two_js, pc, qn; qn.k)
+    qn = (jp = jp"2+", S = 3 / 2, k = 1)
+    @test complete_l_s_L_S(qn.jp, two_js, pc, qn; qn.k).L == "2"
+    #
+    qn = (jp = jp"0+", k = 1)
+    @test_throws ErrorException complete_l_s_L_S(qn.jp, two_js, [pc, pv], qn; qn.k)
+    #
+    qn = (jp = jp"0+", k = 1, L = 0)
+    @test complete_l_s_L_S(qn.jp, two_js, [pc, pv], qn; qn.k).S == "1/2"
+end


### PR DESCRIPTION
Implements a new easy way to create decay chain.
In many cases, of does not need to specify all orbital/spin quantum numbers.

```julia
qn = (jp = jp"0+", k = 1) # incomplete list, not all lsLS are given, in fact, none
complete_l_s_L_S(qn.jp, two_js, pc, qn; qn.k)
```

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/mmikhasenko/ThreeBodyDecays.jl/blob/main/docs/src/90-contributing.md)

- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
