### PR TITLE
feat: Add cosθ projection integrand for three-body decay analysis

### DIFF
--- a/.cspell/project.txt
+++ b/.cspell/project.txt
@@ -18,6 +18,7 @@ guidefontvalign
 helicities
 helicity
 imag
+intergand
 issequential
 jldoctest
 JPAC

--- a/src/ThreeBodyDecays.jl
+++ b/src/ThreeBodyDecays.jl
@@ -74,7 +74,8 @@ include("decay_model.jl")
 export change_basis_3from1, change_basis_1from2, change_basis_2from3
 include("cross_channel.jl")
 
-export phase_space_integrand, projection_integrand
+export phase_space_integrand
+export projection_integrand, project_cosθij_intergand
 include("integrand.jl")
 
 end  # module ThreeBodyDecays

--- a/src/integrand.jl
+++ b/src/integrand.jl
@@ -1,5 +1,5 @@
 """
-	phase_space_integrand(function_σs, ms; k::Int)
+    phase_space_integrand(function_σs, ms; k::Int)
 
 Calculate the phase space integrand for a given function `function_σs`,
 and mass tuple `ms`. The key argument `k` specifies the mapping: `σk->[0,1]`, zk->[0,1].
@@ -38,7 +38,7 @@ function phase_space_integrand(function_σs, ms; k::Int)
 end
 
 """
-	projection_integrand(function_σs, ms, σk; k)
+projection_integrand(function_σs, ms, σk; k)
 
 Calculate the projection integrand for a given function `function_σs`,
 mass tuple `ms`, and Mandelstam variable `σk`, with `k` specified by a keyword argument.
@@ -53,9 +53,9 @@ It returns an integrand function of x, x ∈ [0,1] to pass to a numerical integr
 # Usage
 ```julia
 plot(4.2, 4.6) do e1
-	I = Base.Fix1(unpolarized_intensity, model)
-	integrand = projection_integrand(I, masses(model), e1^2; k = 3)
-	e1 * quadgk(integrand, 0, 1)[1]
+I = Base.Fix1(unpolarized_intensity, model)
+integrand = projection_integrand(I, masses(model), e1^2; k = 3)
+e1 * quadgk(integrand, 0, 1)[1]
 end
 ```
 """
@@ -69,6 +69,45 @@ function projection_integrand(function_σs, ms, σk; k)
         σt = circleorigin(-k, (σi, σj, σk))
         σs = MandelstamTuple{typeof(ms.m0)}(σt)
         return function_σs(σs) * (σj_lims[2] - σj_lims[1])
+    end
+    return integrand
+end
+
+"""
+    project_cosθij_intergand(fs, ms, z; k)
+
+Calculate the integrand for projecting onto cos(θij) for a given function `fs`,
+mass tuple `ms`, and cosine value `z`, with `k` specifying the spectator.
+Returns an integrand function of x ∈ [0,1] to pass to a numerical integrator.
+
+# Arguments
+- `fs`: A function that takes a MandelstamTuple and returns a scalar.
+- `ms`: A MassTuple containing the masses.
+- `z`: The cosine value to project onto.
+- `k`: The spectator index.
+
+# Returns
+- An integrand function for numerical integration.
+
+# Example
+```julia
+let Nb = 100
+    [sum(range(-1, 1, Nb)) do z
+        integrand = project_cosθij_intergand(I, ms, z; k)
+        quadgk(integrand, 0, 1)[1] * 2/Nb
+    end for k in 1:3]
+end
+```
+"""
+function project_cosθij_intergand(fs, ms, z; k)
+    i, j = ij_from_k(k)
+    mi, mj, mk, m0 = ms[i], ms[j], ms[k], ms[4]
+
+    function integrand(xσk)
+        σs = x2σs([xσk, (z + 1) / 2], ms; k)
+        σk = σs[k]
+        jac = sqrt(Kallen(σk, mk^2, m0^2) * Kallen(σk, mi^2, mj^2)) / σk
+        return fs(σs) / 2 * jac * ((m0 - mk)^2 - (mi + mj)^2)
     end
     return integrand
 end

--- a/test/test_integrals.jl
+++ b/test/test_integrals.jl
@@ -48,7 +48,7 @@ end
         sum(range(-1, 1, Nb)) do z
             integrand = project_cosθij_intergand(I, ms, z; k)
             quadgk(integrand, 0, 1)[1] * 2 / Nb
-        end for k in 1:3
+        end for k = 1:3
     ]
 
     # Integration over σk
@@ -56,7 +56,7 @@ end
         sum(range(lims(ms; k)..., Nb)) do σk
             integrand = projection_integrand(I, ms, σk; k)
             quadgk(integrand, 0, 1)[1] * diff(collect(lims(ms; k)))[1] / Nb
-        end for k in 1:3
+        end for k = 1:3
     ]
 
     # Both methods should give approximately the same result


### PR DESCRIPTION
- Implement `project_cosθij_intergand` function to project onto cos(θij)
- Add new function to ThreeBodyDecays module exports
- Include test case to verify cosθ projection integral matches phase space integral

Closes #41 

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/mmikhasenko/ThreeBodyDecays.jl/blob/main/docs/src/90-contributing.md)

- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
