### PR TITLE
Fix macOS CI: use aarch64 with setup-julia

### DIFF
--- a/.cspell/project.txt
+++ b/.cspell/project.txt
@@ -47,6 +47,7 @@ lightgray
 lims
 Lineshapes
 markdownlint
+makedocs
 markerstrokewidth
 markersize
 mathcal
@@ -111,6 +112,16 @@ ylab
 ylim
 yticks
 zenodo
+ansatz
+confs
+iszero
+legendtitlefontsize
+mkpath
+Nakamura
+savefig
+trapz
+xlabel
+ylabel
 absρ
 ηηηphase
 ηηηphaseisplus

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -13,7 +13,8 @@ jobs:
         with:
             os: ${{ matrix.os }}
             version: ${{ matrix.version }}
-            arch: ${{ matrix.arch }}
+            # macOS-latest is arm64; x64 is for ubuntu/windows only
+            arch: ${{ matrix.os == 'macOS-latest' && 'aarch64' || 'x64' }}
             allow_failure: ${{ matrix.allow_failure }}
             run_codecov: ${{ matrix.version == '1' && matrix.os == 'ubuntu-latest' }}
         secrets:
@@ -28,6 +29,4 @@ jobs:
                     - ubuntu-latest
                     - macOS-latest
                     - windows-latest
-                arch:
-                    - x64
                 allow_failure: [false]

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,14 +10,14 @@ From the `docs` folder, with the `docs/Project.toml` environment:
 julia --project=. make.jl
 ```
 
-`make.jl` runs [Literate.jl](https://github.com/JuliaDocs/Literate.jl) on every `*.jl` file under `src/`, writing matching `*.md` files, then calls `makedocs`.
+`make.jl` runs [Literate.jl](https://github.com/fredrikekre/Literate.jl) on every `*.jl` file under `src/`, writing matching `*.md` files, then calls `makedocs`.
 
 Those generated `3*.md` files are listed in the root `.gitignore` (they are recreated in CI by `docs/make.jl`). Edit the `*.jl` sources only.
 
 ## Page map
 
 | Doc | Source | Role |
-|-----|--------|------|
+| --- | --- | --- |
 | ✓ | `src/index.md` | Site home |
 | ✓ | `src/10-energy-dependence.md` | Energy dependence |
 | ✓ | `src/11-quantization-reference.md` | Quantization / conventions |


### PR DESCRIPTION
Closes https://github.com/mmikhasenko/ThreeBodyDecays.jl/issues/108

`macOS-latest` GitHub runners are arm64; `setup-julia` was requesting `x64`, which fails unless `force-arch` is set. This PR selects `aarch64` for macOS and keeps `x64` for Ubuntu and Windows.

**Where the config came from:** the workflow matrix that passes `arch: x64` for every OS (including macOS) was introduced in [`ba59361`](https://github.com/mmikhasenko/ThreeBodyDecays.jl/commit/ba593618710bc4c23439abe0300cff2f71c64eec) (“Apply BestieTemplate”, #44). That was fine while `macOS-latest` was still Intel; CI broke once GitHub moved those runners to Apple Silicon, so the mismatch is latent in that commit rather than a newer repo change.

Made with [Cursor](https://cursor.com)