### PR TITLE
Fix possible_ls returning half-integer orbital angular momentum

### DIFF
--- a/docs/src/31-canonical.jl
+++ b/docs/src/31-canonical.jl
@@ -76,11 +76,10 @@ function A_canonical(chain, angles, two_ms)
 end;
 
 # The `unpolarized_intensity_canonical` function calculates the unpolarized intensity for the canonical formalism.
-unpolarized_intensity_canonical(chain, angles) =
-    sum(itr(chain.tbs.two_js)) do two_ms
-        A = A_canonical(chain, angles, two_ms)
-        abs2(A)
-    end;
+unpolarized_intensity_canonical(chain, angles) = sum(itr(chain.tbs.two_js)) do two_ms
+    A = A_canonical(chain, angles, two_ms)
+    abs2(A)
+end;
 
 #md # ## Example
 

--- a/src/coupling_schemes.jl
+++ b/src/coupling_schemes.jl
@@ -33,8 +33,7 @@ function possible_ls(jp1::SpinParity, jp2::SpinParity; jp::SpinParity)
     two_ls = Vector{Tuple{Int,Int}}(undef, 0)
     for two_s ∈ abs(jp1.two_j-jp2.two_j):2:abs(jp1.two_j+jp2.two_j)
         for two_l ∈ abs(jp.two_j-two_s):2:abs(jp.two_j+two_s)
-            iseven(two_l) || continue  # orbital angular momentum is integer
-            if jp1.p ⊗ jp2.p ⊗ jp.p == (isodd(div(two_l, 2)) ? '-' : '+')
+            if iseven(two_l) && jp1.p ⊗ jp2.p ⊗ jp.p == (isodd(div(two_l, 2)) ? '-' : '+')
                 push!(two_ls, (two_l, two_s))
             end
         end
@@ -210,14 +209,12 @@ named tuple. The function filters the allowed couplings and:
 
 # Example
 ```jldoctest
-julia> two_js = ThreeBodySpins(1, 1, 0; two_h0 = 2);
+julia> two_js, Ps = ThreeBodySpinParities("1/2+", "0-", "0-"; jp0 = "1/2+");
 
-julia> Ps = ThreeBodyParities('+', '+', '+'; P0 = '-');
-
-julia> data = complete_l_s_L_S(jp"1-", two_js, Ps, (; L = 1 / 2, S = 1 / 2); k = 1);
+julia> data = complete_l_s_L_S(jp"1/2-", two_js, Ps, (; L = 0, S = 1 / 2); k = 2);
 
 julia> data
-(L = "1/2", S = "1/2", l = "3/2", s = "1/2")
+(L = "0", S = "1/2", l = "0", s = "1/2")
 ```
 
 See also [`possible_lsLS`](@ref), [`possible_l_s_L_S`](@ref).

--- a/src/coupling_schemes.jl
+++ b/src/coupling_schemes.jl
@@ -33,6 +33,7 @@ function possible_ls(jp1::SpinParity, jp2::SpinParity; jp::SpinParity)
     two_ls = Vector{Tuple{Int,Int}}(undef, 0)
     for two_s ∈ abs(jp1.two_j-jp2.two_j):2:abs(jp1.two_j+jp2.two_j)
         for two_l ∈ abs(jp.two_j-two_s):2:abs(jp.two_j+two_s)
+            iseven(two_l) || continue  # orbital angular momentum is integer
             if jp1.p ⊗ jp2.p ⊗ jp.p == (isodd(div(two_l, 2)) ? '-' : '+')
                 push!(two_ls, (two_l, two_s))
             end

--- a/test/test_couplings.jl
+++ b/test/test_couplings.jl
@@ -23,17 +23,22 @@ end
 end
 
 let
+    @test possible_ls(jp"1/2+", jp"1/2+"; jp = jp"1/2+") == []
+    two_js, Ps = ThreeBodySpinParities("1/2+", "0-", "0-"; jp0 = "1/2+")
+    @test size(possible_lsLS(jp"1/2+", two_js, Ps; k = 1)) == (0, 0)
+    @test all(iseven, first.(possible_ls(jp"3/2-", jp"3-"; jp = jp"1/2+")))
     @test length(possible_ls(jp"3/2-", jp"3-"; jp = jp"1/2+")) == 4
     @test possible_ls("3/2-", "3-"; jp = "1/2+") ==
           possible_ls(jp"3/2-", jp"3-"; jp = jp"1/2+")
     #
     two_js, Ps = ThreeBodySpinParities("1+", "1/2+", "0-"; jp0 = "1/2-")
-    lsLSv = possible_lsLS(jp"1/2+", two_js, Ps; k = 1)
-    @test size(lsLSv) == (1, 2)
+    k = 2
+    lsLSv = possible_lsLS(jp"1/2+", two_js, Ps; k)
+    @test size(lsLSv) == (0, 0)
     #
-    @test length(possible_ls_ij(jp"1+", two_js, Ps; k = 1)) == 1
-    @test length(possible_ls_Rk(jp"1+", two_js, Ps; k = 1)) == 2
-    lsLSv = possible_lsLS(jp"1+", two_js, Ps; k = 1)
+    @test length(possible_ls_ij(jp"1+", two_js, Ps; k)) == 1
+    @test length(possible_ls_Rk(jp"1+", two_js, Ps; k)) == 2
+    lsLSv = possible_lsLS(jp"1+", two_js, Ps; k)
     @test size(lsLSv) == (1, 2)
 end
 

--- a/test/test_inference.jl
+++ b/test/test_inference.jl
@@ -14,7 +14,7 @@ using ThreeBodyDecays.Parameters
     dc = DecayChainLS(;
         k = 3,
         Xlineshape = σ -> 1 / (4.1^2 - σ - 0.1im),
-        jp = jp"3-",
+        jp = jp"1/2-",
         Ps = ThreeBodyParities('+', '-', '-'; P0 = '+'),
         tbs = tbs,
     )

--- a/test/test_integrals.jl
+++ b/test/test_integrals.jl
@@ -44,20 +44,16 @@ end
     # Test integration over cosθ matches phase space integral
     Nb = 500
     # Integration over cosθ
-    cosθ_integral = [
-        sum(range(-1, 1, Nb)) do z
-            integrand = project_cosθij_intergand(I, ms, z; k)
-            quadgk(integrand, 0, 1)[1] * 2 / Nb
-        end for k = 1:3
-    ]
+    cosθ_integral = [sum(range(-1, 1, Nb)) do z
+        integrand = project_cosθij_intergand(I, ms, z; k)
+        quadgk(integrand, 0, 1)[1] * 2 / Nb
+    end for k = 1:3]
 
     # Integration over σk
-    σk_integral = [
-        sum(range(lims(ms; k)..., Nb)) do σk
-            integrand = projection_integrand(I, ms, σk; k)
-            quadgk(integrand, 0, 1)[1] * diff(collect(lims(ms; k)))[1] / Nb
-        end for k = 1:3
-    ]
+    σk_integral = [sum(range(lims(ms; k)..., Nb)) do σk
+        integrand = projection_integrand(I, ms, σk; k)
+        quadgk(integrand, 0, 1)[1] * diff(collect(lims(ms; k)))[1] / Nb
+    end for k = 1:3]
 
     # Both methods should give approximately the same result
     @test isapprox(cosθ_integral[1], σk_integral[1], rtol = 1e-2)

--- a/test/test_ls_amplitude.jl
+++ b/test/test_ls_amplitude.jl
@@ -24,7 +24,7 @@ tbs = ThreeBodySystem(2.0, 1.0, 1.5; m0 = 6.0, two_js)  # 1/2+ 0- 0- 1/2+
 σs = x2σs([0.5, 0.3], tbs.ms; k = 1)
 #
 bw(σ) = 1 / (4.1^2 - σ - 0.1im)
-dc = DecayChainLS(; k = 3, Xlineshape = bw, jp = "3-", Ps, tbs)
+dc = DecayChainLS(; k = 3, Xlineshape = bw, jp = "1/2-", Ps, tbs)
 
 @testset "LS amplitude half-integer spin" begin
     dpp = DalitzPlotPoint(; σs = σs, two_λs = [1, 0, 0, 1])

--- a/test/test_sum_over_polarization.jl
+++ b/test/test_sum_over_polarization.jl
@@ -26,11 +26,11 @@ using ThreeBodyDecays
     bwΣb_x(σ) = 1 / (mΣb_x^2 - σ - 1im * mΣb_x * ΓΣb_x)
     # lineshape
     Ps = ThreeBodyParities('-', '+', '-'; P0 = '+')
-    dc_Σb1 = DecayChainLS(; k = 1, Xlineshape = bw_Σb, tbs, jp = "1+", Ps)
-    dc_Σb3 = DecayChainLS(; k = 3, Xlineshape = bw_Σb, tbs, jp = "1+", Ps)
+    dc_Σb1 = DecayChainLS(; k = 1, Xlineshape = bw_Σb, tbs, jp = "1/2+", Ps)
+    dc_Σb3 = DecayChainLS(; k = 3, Xlineshape = bw_Σb, tbs, jp = "1/2+", Ps)
 
-    dc_Σb_x1 = DecayChainLS(; k = 1, Xlineshape = bwΣb_x, tbs, jp = "3+", Ps)
-    dc_Σb_x3 = DecayChainLS(; k = 3, Xlineshape = bwΣb_x, tbs, jp = "3+", Ps)
+    dc_Σb_x1 = DecayChainLS(; k = 1, Xlineshape = bwΣb_x, tbs, jp = "3/2+", Ps)
+    dc_Σb_x3 = DecayChainLS(; k = 3, Xlineshape = bwΣb_x, tbs, jp = "3/2+", Ps)
 
     full_a(σs, two_λs) =
         sum(amplitude(ch, σs, two_λs) for ch in [dc_Σb1, dc_Σb_x1, dc_Σb3, dc_Σb_x3])


### PR DESCRIPTION
## Summary

Fixes #115.

`possible_ls` / `possible_lsLS` could return half-integer orbital angular momentum values (odd `two_l`, e.g. `two_l = 1` meaning `L = 1/2`). Since orbital angular momentum is always integer, only even `two_l` are physical.

The triangle scan in `possible_ls` allowed odd `two_l` whenever parent and intermediate spin parities had different parity. That rule is fine for spin, but not for orbital angular momentum.

**Change:** skip odd `two_l` in `possible_ls`.

**Example (from the issue):** for `1/2+ + 1/2+ -> 1/2+`, the function previously returned `[(1, 0), (1, 2)]`. It now correctly returns an empty list, because two spin-1/2 daughters have integer total spin `S = 0 or 1`, and integer `S` with integer orbital `L` cannot produce parent `J = 1/2`.

**Tests:** added regression coverage for the issue MWE and updated a few tests that relied on unphysical half-integer-`L` couplings to use valid quantum numbers instead.

## Test plan

- [x] `Pkg.test()` passes locally
- [x] Issue MWE: `possible_ls(jp"1/2+", jp"1/2+"; jp=jp"1/2+")` returns `[]`
- [x] Existing valid couplings unchanged (e.g. `1/2+ -> 1/2+ + 0-` still returns `[(2, 1)]`)


Made with [Cursor](https://cursor.com)